### PR TITLE
Fix non-matching tensor with odd embedding size.

### DIFF
--- a/bert_pytorch/model/embedding/position.py
+++ b/bert_pytorch/model/embedding/position.py
@@ -14,9 +14,10 @@ class PositionalEmbedding(nn.Module):
 
         position = torch.arange(0, max_len).float().unsqueeze(1)
         div_term = (torch.arange(0, d_model, 2).float() * -(math.log(10000.0) / d_model)).exp()
+        odd_len = d_model - div_term.size(-1)
 
         pe[:, 0::2] = torch.sin(position * div_term)
-        pe[:, 1::2] = torch.cos(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term[:odd_len])
 
         pe = pe.unsqueeze(0)
         self.register_buffer('pe', pe)


### PR DESCRIPTION
If `d_model` integer parameter is odd rather than even, then tensor size is not matching (by a difference of 1) on the left and right sides of the assignment:
```python
pe[:, 1::2] = torch.cos(position * div_term)
```

This pull request fixes the problem.