### PR TITLE
Fix require_grad typo

### DIFF
--- a/bert_pytorch/model/embedding/position.py
+++ b/bert_pytorch/model/embedding/position.py
@@ -10,7 +10,7 @@ class PositionalEmbedding(nn.Module):
 
         # Compute the positional encodings once in log space.
         pe = torch.zeros(max_len, d_model).float()
-        pe.require_grad = False
+        pe.requires_grad = False
 
         position = torch.arange(0, max_len).float().unsqueeze(1)
         div_term = (torch.arange(0, d_model, 2).float() * -(math.log(10000.0) / d_model)).exp()


### PR DESCRIPTION
Fix require_grad typos (should be requires_grad).
Before the fix, the code doesn't cause any errors but doesn't do what it's supposed to do.

Also see https://github.com/pytorch/benchmark/pull/1771