### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ This project following Apache 2.0 License as written in LICENSE file
 
 Copyright 2018 Junseong Kim, Scatter Lab, respective BERT contributors
 
-Copyright (c) 2018 Alexander Rush : [The Annotated Trasnformer](https://github.com/harvardnlp/annotated-transformer)
+Copyright (c) 2018 Alexander Rush : [The Annotated Transformer](https://github.com/harvardnlp/annotated-transformer)


### PR DESCRIPTION
Corrected "Trasnformer" to "Transformer" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.